### PR TITLE
Revise the link text displayed by the plugin

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,6 +37,8 @@ markdown_extensions:
               requirements: |
                 altair
                 anywidget
+              link_text: |
+                <img src="https://py.cafe/logos/pycafe_logo.png" style="height: 24px"> **Run and edit this code in Py.Cafe**
   - pymdownx.snippets:
       url_download: true
 ```
@@ -88,6 +90,13 @@ chart = alt.Chart(cars).mark_circle().encode(
 page = alt.JupyterChart(chart)
 ```
 
+The default link text (in markdown format) can be changed in `mkdocs.yml` by changing the `link_text` option in the `format` object, or by adding the `pycafe-link-text` attribute to the code block.
+
+````
+```{.python pycafe-link pycafe-link-text="My custom link text"}
+...
+```
+````
 
 ### Code block with an embedded app
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,5 +17,7 @@ markdown_extensions:
               requirements: |
                 altair
                 anywidget
+              link_text: |
+                <img src="https://py.cafe/logos/pycafe_logo.png" style="height: 24px"> **Run and edit this code in Py.Cafe**
   - pymdownx.snippets:
       url_download: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,9 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dependencies = []
+dependencies = [
+  "markdown"
+]
 
 [project.urls]
 Documentation = "https://github.com/py-cafe/mkdocs-pycafe#readme"

--- a/src/mkdocs_pycafe/__init__.py
+++ b/src/mkdocs_pycafe/__init__.py
@@ -4,12 +4,15 @@ import json
 from functools import partial
 from urllib.parse import quote_plus, urlencode
 
+from markdown import Markdown
+
 base_url = "https://py.cafe"
+default_link_text = """<img src="https://py.cafe/logos/pycafe_logo.png" style="height: 24px"> **Run and edit this code in Py.Cafe**"""
 
 
 def validator(language, inputs, options, attrs, md):
     valid_flags = {"pycafe-link", "pycafe-embed"}
-    valid_inputs = {"requirements", "extra-requirements", "pycafe-type", "pycafe-embed-scale"}
+    valid_inputs = {"requirements", "extra-requirements", "pycafe-type", "pycafe-embed-scale", "pycafe-link-text"}
 
     for k, v in inputs.items():
         if k in valid_inputs:
@@ -23,7 +26,7 @@ def validator(language, inputs, options, attrs, md):
     return True
 
 
-def _formatter(src="", language="", class_name=None, options=None, md="", requirements="", pycafe_type="solara", **kwargs):
+def _formatter(src="", language="", class_name=None, options=None, md="", requirements="", link_text="", pycafe_type="solara", **kwargs):
     from pymdownx.superfences import SuperFencesException
 
     options = options or {}
@@ -33,6 +36,7 @@ def _formatter(src="", language="", class_name=None, options=None, md="", requir
     pycafe_embed_width = options.get("pycafe-embed-width", "100%")
     pycafe_embed_style = options.get("pycafe-embed-style", "border: 1px solid #e6e6e6; border-radius: 8px;")
     pycafe_embed_theme = options.get("pycafe-embed-theme", "light")
+    pycafe_link_text = options.get("pycafe-link-text", link_text)
     pycafe_embed_scale = float(options.get("pycafe-embed-scale", 1.0))
     pycafe_type = options.get("pycafe-type", pycafe_type)
     requirements = "\n".join(options.get("requirements", "").split(",")) or requirements
@@ -45,9 +49,10 @@ def _formatter(src="", language="", class_name=None, options=None, md="", requir
     try:
         if pycafe_link:
             url = pycafe_edit_url(code=src, requirements=requirements, app_type=pycafe_type)
-            text = "Run and edit this code in Py.Cafe"
+            md_renderer = Markdown(extensions=md.registeredExtensions)
+            pycafe_link_text_html = md_renderer.convert(pycafe_link_text)
             target = "_blank"
-            el = el + f"""<a href="{url}" class="PyCafe-button PyCafe-launch-button" target={target}>{text}</a>"""
+            el = el + f"""<a href="{url}" class="PyCafe-button PyCafe-launch-button" target={target}>{pycafe_link_text_html}</a>"""
         if pycafe_embed:
             url = pycafe_embed_url(code=src, requirements=requirements, app_type=pycafe_type, theme=pycafe_embed_theme)
             # e.g. <iframe src="https://py.cafe/embed?apptype=streamlit&theme=light&linkToApp=false#c=..."
@@ -96,6 +101,6 @@ def pycafe_embed_url(*, code: str, requirements, app_type, theme="light"):
     return f"{base_url}/embed?apptype={app_type}&theme={theme}&linkToApp=false#{query}"
 
 
-def formatter(requirements="", type="solara"):  # noqa: A002
+def formatter(requirements="", type="solara", link_text=default_link_text):  # noqa: A002
     """Create a formatter with default requirements and type."""
-    return partial(_formatter, pycafe_type=type, requirements=requirements)
+    return partial(_formatter, pycafe_type=type, requirements=requirements, link_text=link_text)

--- a/src/mkdocs_pycafe/__init__.py
+++ b/src/mkdocs_pycafe/__init__.py
@@ -45,7 +45,7 @@ def _formatter(src="", language="", class_name=None, options=None, md="", requir
     try:
         if pycafe_link:
             url = pycafe_edit_url(code=src, requirements=requirements, app_type=pycafe_type)
-            text = "Run and edit above code in py.cafe"
+            text = "Run and edit this code in Py.Cafe"
             target = "_blank"
             el = el + f"""<a href="{url}" class="PyCafe-button PyCafe-launch-button" target={target}>{text}</a>"""
         if pycafe_embed:


### PR DESCRIPTION
I've made a slight change to the text that's displayed by the plugin. I think it would also help to bold it or make it slightly larger so it is very easy to spot it.

For bonus points, I'd _really_ like a small coffee cup icon too if that's at all possible? Inline next to the text? I think it would help stand out to the user (they'll get used to looking for it and thus being able to easily find and click through). WDYT?

@maartenbreddels