### PR TITLE
Revise link text displayed by MkDocs plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,6 @@ markdown_extensions:
                 altair
                 anywidget
               link_text: |
-                <img src="https://py.cafe/logos/pycafe_logo.png" style="height: 24px"> **Run and edit this code in Py.Cafe**
+                <img src="https://py.cafe/logos/pycafe_logo.png" style="height: 24px"> **Run and edit this code in PyCafe**
   - pymdownx.snippets:
       url_download: true


### PR DESCRIPTION
Now uses the approved nomenclature "PyCafe" rather than "Py.Cafe"